### PR TITLE
	Commit to edit targets file, attempting to isolate each target

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -21,7 +21,6 @@ download_nwis_data <- function(site_nums, parameterCd = '00010')
                          X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
   for (data in repoFiles)
   {
-    download_nwis_site_data(data, parameterCd = '00010')
     these_data <- read_csv(data, col_types = 'ccTdcc')      
     data_out <- bind_rows(data_out, these_data)        # all this should do is append for each iteration
   }
@@ -45,10 +44,6 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
   {  
   site_num <- basename(filepath) %>% 
     stringr::str_extract(pattern = "(?:[0-9]+)")  # this gets the number from the csv identifier
-    
-  # while (nrow(data_out < 1)) {
-  # 
-  # trycatch()
     
   data_out <- readNWISdata(sites=site_num, service="iv", 
                              parameterCd = parameterCd, startDate = startDate, endDate = endDate)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -93,7 +93,8 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
     # data_out <- readNWISdata(sites=site_num, service="iv", 
     #                          parameterCd = parameterCd, startDate = startDate, endDate = endDate)
     # write_csv(data_out, file = filepath)
-    return(filepath)
+    data_out <- read_csv(file.path("1_fetch/out", paste0('nwis_', site_num, '_data.csv')))
+    return(data_out)
   }
   else {
     data_out <- readNWISdata(sites=site_num, service="iv", 
@@ -105,7 +106,7 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
     }
     # -- end of do-not-edit block
     write_csv(data_out, file = filepath)
-    return(filepath)
+    return(data_out)
   }
   
 }

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -16,7 +16,6 @@
 concat_nwis_data <- function(site_nums, parameterCd = '00010')  
 {
   repoFiles <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
-  browser()
   data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),           
                          X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
   for (data in repoFiles)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -8,62 +8,66 @@
 ##
 ## ---------------------------
 ## Notes:
-##     ~  this holds 2 separate functions that download data from leaky server
+##     ~  this holds 2 separate functions that download data from leaky server, and 1 function that creates a 
 ## ---------------------------
 
 
-# 1st fubncitonl
-download_nwis_data <- function(site_nums, parameterCd = '00010')
+# 1st funciton
+download_nwis_data <- function(site_nums, parameterCd = '00010')  
 {
-repoFiles <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
-browser()
-data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),           # standard to dataRetrieval library
-                       X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
-for (data in repoFiles){
-  these_data <- read_csv(data, col_types = 'ccTdcc')                  # set the return inside here
-  finalDf <- bind_rows(data_out, these_data)
-  }
-return(finalDf)
-}
-
-# 1.5st function (is not being used)
-download_nwis_data2 <- function(site_nums, parameterCd = '00010') # c("01432160", "01436690") <- simple vector that works without changing dates
-{
-  # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session;           # changed 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
-  ?browser()
-  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),           # standard to dataRetrieval library
+  repoFiles <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
+  browser()
+  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),           
                          X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
-  
-  # loop through files to download 
-  plzStart <- "2014-05-01"
-  plzStop  <- "2015-05-01"                # paramters modifiable: dcreasing the expanse of time had no affect on build/fail
-  
-  checkExists(download_files, plzStop)      # used to check if we need to update the or not
-  
-  for (download_file in download_files){                               # set start and end dates in here
-    download_nwis_site_data(download_file, parameterCd =  parameterCd, plzStart, plzStop)
-    # read the downloaded data and append it to the existing data.frame
-    
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')                  # set the return inside here
-    data_out <- bind_rows(data_out, these_data)
+  for (data in repoFiles){
+    download_nwis_site_data(data, parameterCd = '00010')
+    these_data <- read_csv(data, col_types = 'ccTdcc')      
+    finalDf <- bind_rows(data_out, these_data)
   }
-  return(data_out)
+  return(finalDf)
 }
 
-# optional function
-checkExsits <- function(download_files, endDate, filepath){
-  for (data in download_files) {
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')    # actually I shouldn't use this
-    if (!dir.exists(data) & !data$dateTime.tail() == endDate) {
-      write.csv(data, filepath)
-    }
-    else 
-      download_nwis_site_data(data, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
-  } 
+# download_nwis_data <- function(site_nums,  parameterCD = '00010')  # site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")
+# {
+#   # create the file names that are needed for download_nwis_site_data
+#   # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
+#   # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
+#   download_files <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
+#   data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),          
+#                          X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
+#   # include dates
+#   plzStart <- "2014-05-01"
+#   plzStop  <- "2015-05-01" 
+#   
+#   # loop through files to download 
+#   for (download_file in download_files){
+#     download_nwis_site_data(download_file, parameterCd = '00010', plzStart, plzStop)
+#     # read the downloaded data and append it to the existing data.frame
+#     these_data <- read_csv(download_file, col_types = 'ccTdcc')
+#     data_out <- bind_rows(data_out, these_data)
+#   }
+#   return(data_out)
+# }
+
+nwis_site_info <- function(fileout, site_data){
+  site_no <- unique(site_data$site_no)
+  site_info <- dataRetrieval::readNWISsite(site_no)
+  write_csv(site_info, fileout)
+  return(fileout)
 }
+
+
+# # optional function
+# checkExsits <- function(download_files, endDate, filepath){
+#   for (data in download_files) {
+#     these_data <- read_csv(download_file, col_types = 'ccTdcc')    # actually I shouldn't use this
+#     if (!dir.exists(data) & !data$dateTime.tail() == endDate) {
+#       write.csv(data, filepath)
+#     }
+#     else 
+#       download_nwis_site_data(data, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
+#   } 
+# }
 
 
 # 2nd function
@@ -76,27 +80,33 @@ nwis_site_info <- function(fileout, site_data){
                    
 
 # 3rd funciton
+# filepaths look something like directory/nwis_01432160_data.csv,     check that the source is in this format
+# remove the directory with basename() and extract the 01432160 with the regular expression match
 download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
-  {  # changed this function signature too
-  # remove the directory with basename() and extract the 01432160 with the regular expression match
+  {  
   site_num <- basename(filepath) %>% 
     stringr::str_extract(pattern = "(?:[0-9]+)")  # this gets the number from the csv identifier
   
-  if (!dir.exists(file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv')))) # this produces warning, but the warning is only about the length of the input, since there is an input vector that is iterated through
+  if (dir.exists(file.path("1_fetch/out", paste0('nwis_', site_num, '_data.csv')))) # tar_make wasn't skipping succsesfully, so I included this if/else
     {
-    # readNWISdata is from the dataRetrieval package
+    # # readNWISdata is from the dataRetrieval package
+    # data_out <- readNWISdata(sites=site_num, service="iv", 
+    #                          parameterCd = parameterCd, startDate = startDate, endDate = endDate)
+    # write_csv(data_out, file = filepath)
+    return(filepath)
+  }
+  else {
     data_out <- readNWISdata(sites=site_num, service="iv", 
                              parameterCd = parameterCd, startDate = startDate, endDate = endDate)
-    write_csv(data_out, file = filepath)
-  }
-
-  # -- simulating a failure-prone web-sevice here, do not edit --
-  set.seed(Sys.time())
-  if (sample(c(T,F,F,F), 1)){
+    # -- simulating a failure-prone web-sevice here, do not edit --
+    set.seed(Sys.time())
+    if (sample(c(T,F,F,F), 1)){
     stop(site_num, ' has failed due to connection timeout. Try tar_make() again')    # does this means it stops at time 1000?
+    }
+    # -- end of do-not-edit block
+    write_csv(data_out, file = filepath)
+    return(filepath)
   }
-  # -- end of do-not-edit block
   
-  return(filepath)
 }
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,21 +1,48 @@
+## ---------------------------
+##
+## Script name: getnwis data
+##
+## Purpose of script:
+##
+## Author: Jack Holbrook (USGS)
+##
+## ---------------------------
+## Notes:
+##     ~  this holds 2 separate functions
+## ---------------------------
 
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
-  
+
+# 1st function
+download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500"), parameterCd = '00010') # c("01432160", "01436690") 
+{
   # create the file names that are needed for download_nwis_site_data
   # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
   # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
+  # old :       download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
+  # new:
   download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
-  data_out <- data.frame()
+  browser()
+  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),
+                         X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
   # loop through files to download 
+  
+  
+  
   for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
+    download_nwis_site_data(download_file, parameterCd =  parameterCd)
     # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
+    
+    these_data <- read_csv(download_file, col_types = 'ccTdcc')                  # set the return inside here
     data_out <- bind_rows(data_out, these_data)
+    
+    # returning each csv separatlry
+    #return(data_out)
   }
   return(data_out)
 }
 
+
+# 2nd function
 nwis_site_info <- function(fileout, site_data){
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
@@ -24,6 +51,7 @@ nwis_site_info <- function(fileout, site_data){
 }
 
 
+# rd funciton
 download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
   
   # filepaths look something like directory/nwis_01432160_data.csv,

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -8,37 +8,61 @@
 ##
 ## ---------------------------
 ## Notes:
-##     ~  this holds 2 separate functions
+##     ~  this holds 2 separate functions that download data from leaky server
 ## ---------------------------
 
 
-# 1st function
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500"), parameterCd = '00010') # c("01432160", "01436690") 
+# 1st fubncitonl
+download_nwis_data <- function(site_nums, parameterCd = '00010')
+{
+repoFiles <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
+browser()
+data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),           # standard to dataRetrieval library
+                       X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
+for (data in repoFiles){
+  these_data <- read_csv(data, col_types = 'ccTdcc')                  # set the return inside here
+  finalDf <- bind_rows(data_out, these_data)
+  }
+return(finalDf)
+}
+
+# 1.5st function (is not being used)
+download_nwis_data2 <- function(site_nums, parameterCd = '00010') # c("01432160", "01436690") <- simple vector that works without changing dates
 {
   # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
+  # tempdir() creates a temporary directory that is wiped out when you start a new R session;           # changed 
   # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  # old :       download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
-  # new:
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
-  browser()
-  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),
+  download_files <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
+  ?browser()
+  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),           # standard to dataRetrieval library
                          X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
+  
   # loop through files to download 
+  plzStart <- "2014-05-01"
+  plzStop  <- "2015-05-01"                # paramters modifiable: dcreasing the expanse of time had no affect on build/fail
   
+  checkExists(download_files, plzStop)      # used to check if we need to update the or not
   
-  
-  for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd =  parameterCd)
+  for (download_file in download_files){                               # set start and end dates in here
+    download_nwis_site_data(download_file, parameterCd =  parameterCd, plzStart, plzStop)
     # read the downloaded data and append it to the existing data.frame
     
     these_data <- read_csv(download_file, col_types = 'ccTdcc')                  # set the return inside here
     data_out <- bind_rows(data_out, these_data)
-    
-    # returning each csv separatlry
-    #return(data_out)
   }
   return(data_out)
+}
+
+# optional function
+checkExsits <- function(download_files, endDate, filepath){
+  for (data in download_files) {
+    these_data <- read_csv(download_file, col_types = 'ccTdcc')    # actually I shouldn't use this
+    if (!dir.exists(data) & !data$dateTime.tail() == endDate) {
+      write.csv(data, filepath)
+    }
+    else 
+      download_nwis_site_data(data, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
+  } 
 }
 
 
@@ -49,28 +73,30 @@ nwis_site_info <- function(fileout, site_data){
   write_csv(site_info, fileout)
   return(fileout)
 }
+                   
 
-
-# rd funciton
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
-  
-  # filepaths look something like directory/nwis_01432160_data.csv,
+# 3rd funciton
+download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
+  {  # changed this function signature too
   # remove the directory with basename() and extract the 01432160 with the regular expression match
   site_num <- basename(filepath) %>% 
-    stringr::str_extract(pattern = "(?:[0-9]+)")
+    stringr::str_extract(pattern = "(?:[0-9]+)")  # this gets the number from the csv identifier
   
-  # readNWISdata is from the dataRetrieval package
-  data_out <- readNWISdata(sites=site_num, service="iv", 
-                           parameterCd = parameterCd, startDate = startDate, endDate = endDate)
+  if (!dir.exists(file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv')))) # this produces warning, but the warning is only about the length of the input, since there is an input vector that is iterated through
+    {
+    # readNWISdata is from the dataRetrieval package
+    data_out <- readNWISdata(sites=site_num, service="iv", 
+                             parameterCd = parameterCd, startDate = startDate, endDate = endDate)
+    write_csv(data_out, file = filepath)
+  }
 
   # -- simulating a failure-prone web-sevice here, do not edit --
   set.seed(Sys.time())
   if (sample(c(T,F,F,F), 1)){
-    stop(site_num, ' has failed due to connection timeout. Try tar_make() again')
+    stop(site_num, ' has failed due to connection timeout. Try tar_make() again')    # does this means it stops at time 1000?
   }
   # -- end of do-not-edit block
   
-  write_csv(data_out, file = filepath)
   return(filepath)
 }
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -13,7 +13,7 @@
 
 
 # 1st funciton
-download_nwis_data <- function(site_nums, parameterCd = '00010')  
+concat_nwis_data <- function(site_nums, parameterCd = '00010')  
 {
   repoFiles <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
   browser()
@@ -56,6 +56,7 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
   
   write_csv(data_out, file = filepath)
   return(filepath)
+  #return(data_out)
   
 }
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -19,95 +19,48 @@ download_nwis_data <- function(site_nums, parameterCd = '00010')
   browser()
   data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),           
                          X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
-  for (data in repoFiles){
+  for (data in repoFiles)
+  {
     download_nwis_site_data(data, parameterCd = '00010')
     these_data <- read_csv(data, col_types = 'ccTdcc')      
-    finalDf <- bind_rows(data_out, these_data)
+    data_out <- bind_rows(data_out, these_data)        # all this should do is append for each iteration
   }
-  return(finalDf)
+  return(data_out)
 }
 
-# download_nwis_data <- function(site_nums,  parameterCD = '00010')  # site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")
-# {
-#   # create the file names that are needed for download_nwis_site_data
-#   # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-#   # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-#   download_files <- file.path("1_fetch/out", paste0('nwis_', site_nums, '_data.csv'))
-#   data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(),          
-#                          X_00010_00000 = c(), X00010_00000_cd = c(), tz_cd = c())
-#   # include dates
-#   plzStart <- "2014-05-01"
-#   plzStop  <- "2015-05-01" 
-#   
-#   # loop through files to download 
-#   for (download_file in download_files){
-#     download_nwis_site_data(download_file, parameterCd = '00010', plzStart, plzStop)
-#     # read the downloaded data and append it to the existing data.frame
-#     these_data <- read_csv(download_file, col_types = 'ccTdcc')
-#     data_out <- bind_rows(data_out, these_data)
-#   }
-#   return(data_out)
-# }
 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(fileout, site_data)
+{
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)
   return(fileout)
 }
+            
 
-
-# # optional function
-# checkExsits <- function(download_files, endDate, filepath){
-#   for (data in download_files) {
-#     these_data <- read_csv(download_file, col_types = 'ccTdcc')    # actually I shouldn't use this
-#     if (!dir.exists(data) & !data$dateTime.tail() == endDate) {
-#       write.csv(data, filepath)
-#     }
-#     else 
-#       download_nwis_site_data(data, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
-#   } 
-# }
-
-
-# 2nd function
-nwis_site_info <- function(fileout, site_data){
-  site_no <- unique(site_data$site_no)
-  site_info <- dataRetrieval::readNWISsite(site_no)
-  write_csv(site_info, fileout)
-  return(fileout)
-}
-                   
-
-# 3rd funciton
+# 3rd function
 # filepaths look something like directory/nwis_01432160_data.csv,     check that the source is in this format
 # remove the directory with basename() and extract the 01432160 with the regular expression match
 download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
   {  
   site_num <- basename(filepath) %>% 
     stringr::str_extract(pattern = "(?:[0-9]+)")  # this gets the number from the csv identifier
-  
-  if (dir.exists(file.path("1_fetch/out", paste0('nwis_', site_num, '_data.csv')))) # tar_make wasn't skipping succsesfully, so I included this if/else
-    {
-    # # readNWISdata is from the dataRetrieval package
-    # data_out <- readNWISdata(sites=site_num, service="iv", 
-    #                          parameterCd = parameterCd, startDate = startDate, endDate = endDate)
-    # write_csv(data_out, file = filepath)
-    data_out <- read_csv(file.path("1_fetch/out", paste0('nwis_', site_num, '_data.csv')))
-    return(data_out)
-  }
-  else {
-    data_out <- readNWISdata(sites=site_num, service="iv", 
+    
+  # while (nrow(data_out < 1)) {
+  # 
+  # trycatch()
+    
+  data_out <- readNWISdata(sites=site_num, service="iv", 
                              parameterCd = parameterCd, startDate = startDate, endDate = endDate)
-    # -- simulating a failure-prone web-sevice here, do not edit --
-    set.seed(Sys.time())
-    if (sample(c(T,F,F,F), 1)){
-    stop(site_num, ' has failed due to connection timeout. Try tar_make() again')    # does this means it stops at time 1000?
-    }
-    # -- end of do-not-edit block
-    write_csv(data_out, file = filepath)
-    return(data_out)
+  # -- simulating a failure-prone web-sevice here, do not edit --
+  set.seed(Sys.time())
+  if (sample(c(T,F,F,F), 1)){
+  stop(site_num, ' has failed due to connection timeout. Try tar_make() again')    # does this means it stops at time 1000?
   }
+  # -- end of do-not-edit block
+  
+  write_csv(data_out, file = filepath)
+  return(filepath)
   
 }
 

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,11 +1,13 @@
-process_data <- function(nwis_data){
+process_data <- function(nwis_data)
+  {
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd)
   
   return(nwis_data_clean)
 }
 
-annotate_data <- function(site_data_clean, site_filename){
+annotate_data <- function(site_data_clean, site_filename)
+  {
   site_info <- read_csv(site_filename)
   annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
@@ -14,6 +16,7 @@ annotate_data <- function(site_data_clean, site_filename){
 }
 
 
-style_data <- function(site_data_annotated){
+style_data <- function(site_data_annotated)
+  {
   mutate(site_data_annotated, station_name = as.factor(station_name))
 }

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -8,14 +8,19 @@ process_data <- function(nwis_data)
   return(nwis_data_clean)
 }
 
-# cppFunction('Dataframe get_annotatedData(Dataframe site_data_clean, string site_filename){
-#   
+# Rcpp::sourceCpp(code='
+# #include <Rcpp.h>
+# using namespace Rcpp;
+# 
+# // [[Rcpp::export]]
+# DataFrame left_joinCpp(DataFrame site_data_clean, DataFrame site_info, Function left_join) {
+# return(left_joinCpp(site_data_clean, DataFrame site_info, "site_no"));
 # }')
 
 annotate_data <- function(site_data_clean, site_filename)
   {
   site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
+  annotated_data <- left_join(site_data_clean, site_info, "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
   
   return(annotated_data)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,3 +1,5 @@
+#library(Rcpp)
+
 process_data <- function(nwis_data)
   {
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
@@ -5,6 +7,10 @@ process_data <- function(nwis_data)
   
   return(nwis_data_clean)
 }
+
+# cppFunction('Dataframe get_annotatedData(Dataframe site_data_clean, string site_filename){
+#   
+# }')
 
 annotate_data <- function(site_data_clean, site_filename)
   {

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,4 +1,4 @@
-plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
+plot_nwis_timeseries <- function(fileout, site_data_styled, width = p_width, height = p_height, units = p_units){
   
   ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()

--- a/_targets.R
+++ b/_targets.R
@@ -2,7 +2,7 @@ library(targets)
 source("1_fetch/src/get_nwis_data.R")
 source("2_process/src/process_and_style.R")
 source("3_visualize/src/plot_timeseries.R")
-tar_option_set(debug = "site_data")
+#tar_option_set(debug = "site_data")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr

--- a/_targets.R
+++ b/_targets.R
@@ -24,31 +24,31 @@ tar_target(
   site_data,
   download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data, I think this function needs to be called first
 ), 
-tar_target(
-  nwis_01427207_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
-  format = "file"
-),
-tar_target(
-  nwis_01432160_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
-  format = "file"
-),
-tar_target(
-  nwis_01435000_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
-  format = "file"
-),
-tar_target(
-  nwis_01436690_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
-  format = "file"
-  ),
-tar_target(
-  nwis_01466500_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
-  format = "file"
-  ),                                                # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
+# tar_target(
+#   nwis_01427207_data_csv,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
+#   format = "file"
+# ),
+# tar_target(
+#   nwis_01432160_data_csv,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
+#   format = "file"
+# ),
+# tar_target(
+#   nwis_01435000_data_csv,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
+#   format = "file"
+# ),
+# tar_target(
+#   nwis_01436690_data_csv,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
+#   format = "file"
+#   ),
+# tar_target(
+#   nwis_01466500_data_csv,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
+#   format = "file"
+#   ),                                                # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
 tar_target(
   site_info_csv,
   nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),

--- a/_targets.R
+++ b/_targets.R
@@ -19,42 +19,43 @@ p_units <- "in"
 
 
 p1_targets_list <- list(
-                        # using separate functions for each target
 tar_target(
   site_data,
   download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data, I think this function needs to be called first
 ), 
-# tar_target(
-#   nwis_01427207_data_csv,
-#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
-#   format = "file"
-# ),
-# tar_target(
-#   nwis_01432160_data_csv,
-#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
-#   format = "file"
-# ),
-# tar_target(
-#   nwis_01435000_data_csv,
-#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
-#   format = "file"
-# ),
-# tar_target(
-#   nwis_01436690_data_csv,
-#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
-#   format = "file"
-#   ),
-# tar_target(
-#   nwis_01466500_data_csv,
-#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
-#   format = "file"
-#   ),                                                # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
+tar_target(
+  nwis_01427207_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
+  format = "file"
+),
+tar_target(
+  nwis_01432160_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
+  format = "file"
+),
+tar_target(
+  nwis_01435000_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
+  format = "file"
+),
+tar_target(
+  nwis_01436690_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01436690_data.csv'),
+  format = "file"
+  ),
+tar_target(
+  nwis_01466500_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
+  format = "file"
+  ),                                                # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
 tar_target(
   site_info_csv,
   nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
   format = "file"
   )
+  
 )
+
 
 
 p2_targets_list <- list(

--- a/_targets.R
+++ b/_targets.R
@@ -7,7 +7,11 @@ tar_option_set(debug = "site_data")
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 
+####            p1_targets_list
+site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")
 ####
+
+####            p3_targets_list
 p_width <- 12
 p_height <- 7
 p_units <- "in"
@@ -15,41 +19,42 @@ p_units <- "in"
 
 
 p1_targets_list <- list(
-  tar_target(
-    site_data,
-    download_nwis_data(),
+                        # using separate functions for each target
+tar_target(
+  nwis_01427207_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
+  format = "file"
+),
+tar_target(
+  nwis_01432160_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01436690_data.csv'),
+  format = "file"
+),
+tar_target(
+  nwis_01435000_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
+  format = "file"
+),
+tar_target(
+  nwis_01436690_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
+  format = "file"
   ),
-  tar_target(
-    site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
-    format = "file"
-#  )
+tar_target(
+  nwis_01466500_data_csv,
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
+  format = "file"
+  ),
+tar_target(
+  site_data,
+  download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data
+),                                                 # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
+tar_target(
+  site_info_csv,
+  nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
+  format = "file"
   )
-# tar_target(
-#   nwis_01427207_data_csv,
-#   download_nwis_site_data('1_fetch/out/nwis_01466500_data.csv'),
-#   format = "file"
-# ),
-# tar_target(
-#   nwis_01427207_data_csv,
-#   download_nwis_site_data('1_fetch/out/nwis_01436690_data.csv'),
-#   format = "file"
-# ),
-# tar_target(
-#   nwis_01427207_data_csv,
-#   download_nwis_site_data('1_fetch/out/nwis_01432160_data.csv'),
-#   format = "file"
-# ),
-#   # tar_target(
-#   #   nwis_01427207_data_csv,
-#   #   download_nwis_site_data('1_fetch/out/nwis_01427207_data.csv'),
-#   #   format = "file"
-#   # ),
-#   tar_target(
-#     nwis_01435000_data_csv,
-#     download_nwis_site_data('1_fetch/out/nwis_01435000_data.csv'),
-#     format = "file"
-  )
+)
 
 
 p2_targets_list <- list(

--- a/_targets.R
+++ b/_targets.R
@@ -2,9 +2,17 @@ library(targets)
 source("1_fetch/src/get_nwis_data.R")
 source("2_process/src/process_and_style.R")
 source("3_visualize/src/plot_timeseries.R")
+tar_option_set(debug = "site_data")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+
+####
+p_width <- 12
+p_height <- 7
+p_units <- "in"
+####
+
 
 p1_targets_list <- list(
   tar_target(
@@ -15,8 +23,34 @@ p1_targets_list <- list(
     site_info_csv,
     nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
     format = "file"
+#  )
   )
-)
+# tar_target(
+#   nwis_01427207_data_csv,
+#   download_nwis_site_data('1_fetch/out/nwis_01466500_data.csv'),
+#   format = "file"
+# ),
+# tar_target(
+#   nwis_01427207_data_csv,
+#   download_nwis_site_data('1_fetch/out/nwis_01436690_data.csv'),
+#   format = "file"
+# ),
+# tar_target(
+#   nwis_01427207_data_csv,
+#   download_nwis_site_data('1_fetch/out/nwis_01432160_data.csv'),
+#   format = "file"
+# ),
+#   # tar_target(
+#   #   nwis_01427207_data_csv,
+#   #   download_nwis_site_data('1_fetch/out/nwis_01427207_data.csv'),
+#   #   format = "file"
+#   # ),
+#   tar_target(
+#     nwis_01435000_data_csv,
+#     download_nwis_site_data('1_fetch/out/nwis_01435000_data.csv'),
+#     format = "file"
+  )
+
 
 p2_targets_list <- list(
   tar_target(
@@ -28,15 +62,16 @@ p2_targets_list <- list(
     annotate_data(site_data_clean, site_filename = site_info_csv)
   ),
   tar_target(
-    site_data_styled,
-    style_data(site_data_annotated)
+    site_data_styled,             # this is used to create the plot, this is why there is no out folder in process
+    style_data(site_data_annotated)    
   )
 )
 
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled),
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
+                         width = p_width, height = p_height, units = p_units),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -21,18 +21,22 @@ p_units <- "in"
 p1_targets_list <- list(
                         # using separate functions for each target
 tar_target(
+  site_data,
+  download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data, I think this function needs to be called first
+), 
+tar_target(
   nwis_01427207_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
   format = "file"
 ),
 tar_target(
   nwis_01432160_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01436690_data.csv'),
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
   format = "file"
 ),
 tar_target(
   nwis_01435000_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
   format = "file"
 ),
 tar_target(
@@ -42,13 +46,9 @@ tar_target(
   ),
 tar_target(
   nwis_01466500_data_csv,
-  download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
+  download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
   format = "file"
-  ),
-tar_target(
-  site_data,
-  download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data
-),                                                 # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
+  ),                                                # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
 tar_target(
   site_info_csv,
   nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),

--- a/_targets.R
+++ b/_targets.R
@@ -20,10 +20,6 @@ p_units <- "in"
 
 p1_targets_list <- list(
 tar_target(
-  site_data,
-  download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data, I think this function needs to be called first
-), 
-tar_target(
   nwis_01427207_data_csv,
   download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
   format = "file"
@@ -47,7 +43,12 @@ tar_target(
   nwis_01466500_data_csv,
   download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
   format = "file"
-  ),                                                # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
+  ),
+tar_target(
+  site_data,
+  download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data, I think this function needs to be called first
+), 
+# site_data is the concatenatd dataframe of the seperate csv files, should get this to return
 tar_target(
   site_info_csv,
   nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),

--- a/_targets.R
+++ b/_targets.R
@@ -44,19 +44,43 @@ tar_target(
   download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
   format = "file"
   ),
+
+  ##### changing this portion to allow return type of object
+ 
+# tar_target(                   # to enable these, change the return type of download_nwis_site_data
+#   nwis_01427207_data,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01427207_data.csv'),
+# ),
+# tar_target(
+#   nwis_01432160_data,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01432160_data.csv'),
+# ),
+# tar_target(
+#   nwis_01435000_data,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01435000_data.csv'),
+# ),
+# tar_target(
+#   nwis_01436690_data,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01436690_data.csv'),
+# ),
+# tar_target(
+#   nwis_01466500_data,
+#   download_nwis_site_data(filepath = '1_fetch/out/nwis_01466500_data.csv'),
+# ),
+
+  #####
+
 tar_target(
   site_data,
-  download_nwis_data(site_nums = site_nums),       # where this function is now focused on getting the site_data, I think this function needs to be called first
-), 
+  concat_nwis_data(site_nums = site_nums), 
+  ),
 # site_data is the concatenatd dataframe of the seperate csv files, should get this to return
 tar_target(
   site_info_csv,
   nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
   format = "file"
+    )
   )
-  
-)
-
 
 
 p2_targets_list <- list(


### PR DESCRIPTION

Update: 
            modified function download_nwis_data to read from all the files in the fetch/out directory and concat them.
            For function download_nwis_site_data, this is called seperatley for each target in the terminal. The goal was to read each target as its full self, and then write code that would allow the targets to skip if the file was already located in the directory.
targets return form as 'file' in order to skip build on repeated runs



![targets2visnetwork](https://user-images.githubusercontent.com/85192408/123145801-0e56c700-d412-11eb-8013-faaddc606696.PNG)